### PR TITLE
Preview v2: single cinematic storytelling page

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -3,15 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Izvēlieties sava biznesa veidu | Vdigital</title>
-  <meta name="description" content="Apskatiet, kā varētu izskatīties jūsu mājas lapa — restorānam, skaistumkopšanai, fitnesam un citiem uzņēmumu veidiem." />
-  <meta name="robots" content="index, follow" />
+  <title>Kā izskatīsies jūsu mājas lapa | Vdigital</title>
+  <meta name="description" content="Katrs bizness ir atšķirīgs. Apskatiet, kāda pieeja der tieši jūsu uzņēmumam — restorānam, skaistumkopšanai vai fitnesa klubam." />
   <link rel="canonical" href="https://vdigital.lv/preview" />
   <link rel="icon" href="/favicon.png" type="image/png" />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://vdigital.lv/preview" />
-  <meta property="og:title" content="Izvēlieties sava biznesa veidu | Vdigital" />
-  <meta property="og:image" content="https://vdigital.lv/logo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -20,11 +15,523 @@
   <link rel="stylesheet" href="css/nav.css" />
   <link rel="stylesheet" href="css/footer.css" />
   <link rel="stylesheet" href="css/responsive.css" />
-  <link rel="stylesheet" href="css/preview.css" />
+  <style>
+
+/* =============================================
+   PREVIEW V2 — Cinematic storytelling page
+   ============================================= */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ── STICKY NAV PILLS ── */
+.pv-nav {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  display: flex;
+  gap: 8px;
+  background: rgba(8,9,13,0.7);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 999px;
+  padding: 6px 8px;
+  transition: opacity 0.4s;
+}
+.pv-nav__pill {
+  background: transparent;
+  border: none;
+  color: rgba(255,255,255,0.45);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 7px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.25s;
+  white-space: nowrap;
+}
+.pv-nav__pill:hover { color: #fff; }
+.pv-nav__pill.active {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+}
+
+/* ── INTRO HERO ── */
+.pv-intro {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 120px 24px 80px;
+  position: relative;
+  overflow: hidden;
+  background: #08090d;
+}
+.pv-intro__grid {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 48px 48px;
+  pointer-events: none;
+}
+.pv-intro__glow {
+  position: absolute;
+  top: 20%; left: 50%;
+  transform: translateX(-50%);
+  width: 800px; height: 500px;
+  background: radial-gradient(ellipse, rgba(108,99,255,0.15) 0%, transparent 65%);
+  pointer-events: none;
+}
+.pv-intro__content { position: relative; z-index: 1; max-width: 760px; }
+.pv-intro__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(108,99,255,0.12);
+  border: 1px solid rgba(108,99,255,0.25);
+  border-radius: 999px;
+  color: #a78bfa;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 16px;
+  margin-bottom: 28px;
+}
+.pv-intro__eyebrow span { width: 6px; height: 6px; background: #a78bfa; border-radius: 50%; animation: pulse 2s infinite; }
+@keyframes pulse { 0%,100%{opacity:1;transform:scale(1);} 50%{opacity:0.4;transform:scale(0.7);} }
+.pv-intro h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.8rem, 6vw, 5rem);
+  font-weight: 900;
+  line-height: 1.08;
+  color: #fff;
+  margin-bottom: 24px;
+  letter-spacing: -0.02em;
+}
+.pv-intro h1 em {
+  font-style: normal;
+  background: linear-gradient(135deg, #a78bfa 0%, #6c63ff 50%, #38bdf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.pv-intro__sub {
+  font-size: 1.15rem;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.7;
+  max-width: 540px;
+  margin: 0 auto 48px;
+}
+.pv-intro__scroll {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: rgba(255,255,255,0.25);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  animation: scrollBounce 2.5s infinite;
+}
+.pv-intro__scroll svg { opacity: 0.4; }
+@keyframes scrollBounce { 0%,100%{transform:translateY(0);} 50%{transform:translateY(6px);} }
+
+/* ── CATEGORY SECTIONS ── */
+.pv-cat {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+
+/* Video / photo background */
+.pv-cat__bg {
+  position: absolute; inset: 0;
+  z-index: 0;
+}
+.pv-cat__bg video,
+.pv-cat__bg img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+.pv-cat__overlay {
+  position: absolute; inset: 0;
+  z-index: 1;
+}
+
+/* Restaurant overlay — warm dark amber */
+.pv-cat--restoran .pv-cat__overlay {
+  background: linear-gradient(135deg,
+    rgba(10,6,0,0.92) 0%,
+    rgba(20,10,0,0.85) 40%,
+    rgba(8,9,13,0.75) 100%);
+}
+/* Salon overlay — dark rose */
+.pv-cat--salons .pv-cat__overlay {
+  background: linear-gradient(135deg,
+    rgba(10,0,8,0.93) 0%,
+    rgba(20,0,15,0.85) 40%,
+    rgba(8,9,13,0.75) 100%);
+}
+/* Fitness overlay — dark orange */
+.pv-cat--fitness .pv-cat__overlay {
+  background: linear-gradient(135deg,
+    rgba(10,4,0,0.93) 0%,
+    rgba(20,8,0,0.85) 40%,
+    rgba(8,9,13,0.75) 100%);
+}
+
+.pv-cat__inner {
+  position: relative; z-index: 2;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 100px 48px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 80px;
+  align-items: center;
+  width: 100%;
+}
+
+/* Left — story */
+.pv-cat__story {}
+.pv-cat__number {
+  font-family: var(--font-display);
+  font-size: 6rem;
+  font-weight: 900;
+  line-height: 1;
+  margin-bottom: -8px;
+  opacity: 0.06;
+  color: #fff;
+  letter-spacing: -0.04em;
+}
+.pv-cat__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 20px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  border: 1px solid;
+}
+.pv-cat--restoran .pv-cat__label { color: #f59e0b; border-color: rgba(245,158,11,0.3); background: rgba(245,158,11,0.08); }
+.pv-cat--salons   .pv-cat__label { color: #ec4899; border-color: rgba(236,72,153,0.3); background: rgba(236,72,153,0.08); }
+.pv-cat--fitness  .pv-cat__label { color: #f97316; border-color: rgba(249,115,22,0.3); background: rgba(249,115,22,0.08); }
+
+.pv-cat__title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3.5vw, 3rem);
+  font-weight: 800;
+  color: #fff;
+  line-height: 1.15;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+.pv-cat--restoran .pv-cat__title span { color: #f59e0b; }
+.pv-cat--salons   .pv-cat__title span { color: #ec4899; }
+.pv-cat--fitness  .pv-cat__title span { color: #f97316; }
+
+.pv-cat__quote {
+  font-size: 1.05rem;
+  color: rgba(255,255,255,0.55);
+  line-height: 1.7;
+  margin-bottom: 32px;
+  font-style: italic;
+  border-left: 2px solid;
+  padding-left: 16px;
+}
+.pv-cat--restoran .pv-cat__quote { border-color: rgba(245,158,11,0.4); }
+.pv-cat--salons   .pv-cat__quote { border-color: rgba(236,72,153,0.4); }
+.pv-cat--fitness  .pv-cat__quote { border-color: rgba(249,115,22,0.4); }
+
+/* Elements list */
+.pv-cat__elements {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 36px;
+}
+.pv-cat__el {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 14px 16px;
+  backdrop-filter: blur(8px);
+  transition: border-color 0.2s, background 0.2s;
+}
+.pv-cat__el:hover {
+  background: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.14);
+}
+.pv-cat__el-icon {
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+.pv-cat--restoran .pv-cat__el-icon { background: rgba(245,158,11,0.15); }
+.pv-cat--salons   .pv-cat__el-icon { background: rgba(236,72,153,0.15); }
+.pv-cat--fitness  .pv-cat__el-icon { background: rgba(249,115,22,0.15); }
+.pv-cat__el-body {}
+.pv-cat__el-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 2px;
+}
+.pv-cat__el-desc {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.4);
+  line-height: 1.5;
+}
+
+/* Right — live preview card */
+.pv-cat__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pv-preview-hero {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 24px 60px rgba(0,0,0,0.5);
+  position: relative;
+  height: 220px;
+  display: flex;
+  align-items: flex-end;
+  padding: 20px;
+}
+.pv-preview-hero__bg {
+  position: absolute; inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.55);
+  transition: transform 8s ease;
+}
+.pv-preview-hero:hover .pv-preview-hero__bg { transform: scale(1.04); }
+.pv-preview-hero__content { position: relative; z-index: 1; }
+.pv-preview-hero__name {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #fff;
+  margin-bottom: 4px;
+}
+.pv-preview-hero__sub {
+  font-size: 0.75rem;
+  color: rgba(255,255,255,0.6);
+  margin-bottom: 12px;
+}
+.pv-preview-cta {
+  display: inline-block;
+  border-radius: 8px;
+  padding: 7px 16px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #fff;
+  cursor: pointer;
+}
+.pv-cat--restoran .pv-preview-cta { background: #f59e0b; }
+.pv-cat--salons   .pv-preview-cta { background: #ec4899; }
+.pv-cat--fitness  .pv-preview-cta { background: #f97316; }
+
+/* Preview cards row */
+.pv-preview-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.pv-preview-card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 10px;
+  padding: 14px 12px;
+  backdrop-filter: blur(8px);
+}
+.pv-preview-card__top {
+  font-size: 1.2rem;
+  margin-bottom: 6px;
+}
+.pv-preview-card__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 3px;
+}
+.pv-preview-card__val {
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.35);
+}
+
+/* Review strip */
+.pv-preview-review {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 10px;
+  padding: 14px 16px;
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.pv-preview-review__stars { color: #f59e0b; font-size: 0.75rem; margin-bottom: 4px; }
+.pv-preview-review p { font-size: 0.75rem; color: rgba(255,255,255,0.5); line-height: 1.5; }
+.pv-preview-review__author { font-size: 0.68rem; color: rgba(255,255,255,0.25); margin-top: 6px; }
+.pv-preview-review__avatar {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 0.9rem;
+  background: rgba(255,255,255,0.08);
+}
+
+/* ── CLOSING CTA ── */
+.pv-cta {
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 120px 24px;
+  position: relative;
+  overflow: hidden;
+  background: #08090d;
+}
+.pv-cta__glow {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%,-50%);
+  width: 900px; height: 600px;
+  background: radial-gradient(ellipse, rgba(108,99,255,0.12) 0%, transparent 65%);
+  pointer-events: none;
+}
+.pv-cta__inner { position: relative; z-index: 1; max-width: 640px; }
+.pv-cta__kicker {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #a78bfa;
+  margin-bottom: 20px;
+}
+.pv-cta h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  font-weight: 900;
+  color: #fff;
+  line-height: 1.1;
+  margin-bottom: 20px;
+  letter-spacing: -0.02em;
+}
+.pv-cta h2 span {
+  background: linear-gradient(135deg, #a78bfa, #6c63ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.pv-cta p {
+  color: rgba(255,255,255,0.45);
+  font-size: 1rem;
+  line-height: 1.7;
+  margin-bottom: 40px;
+}
+.pv-cta__btns { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+/* ── VDIGITAL STICKY BAR ── */
+.vd-bar {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  z-index: 200;
+  background: rgba(8,9,13,0.92);
+  backdrop-filter: blur(16px);
+  border-top: 1px solid rgba(255,255,255,0.07);
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+.vd-bar__text {
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.4);
+}
+.vd-bar__text strong { color: rgba(255,255,255,0.8); }
+.vd-bar__cta {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 6px 18px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+}
+.vd-bar__cta:hover { opacity: 0.85; }
+
+/* ── DIVIDER ── */
+.pv-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent);
+  margin: 0;
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 900px) {
+  .pv-cat__inner {
+    grid-template-columns: 1fr;
+    gap: 40px;
+    padding: 80px 24px;
+  }
+  .pv-cat__number { font-size: 4rem; }
+}
+@media (max-width: 600px) {
+  .pv-nav { display: none; }
+  .pv-intro h1 { font-size: 2.4rem; }
+  .pv-preview-cards { grid-template-columns: 1fr 1fr; }
+  .vd-bar { flex-wrap: wrap; gap: 8px; padding: 10px 16px; }
+}
+
+/* scroll reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+.reveal.visible {
+  opacity: 1;
+  transform: none;
+}
+.reveal-delay-1 { transition-delay: 0.1s; }
+.reveal-delay-2 { transition-delay: 0.2s; }
+.reveal-delay-3 { transition-delay: 0.32s; }
+.reveal-delay-4 { transition-delay: 0.44s; }
+
+  </style>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('vd-theme') || 'dark');</script>
 </head>
-<body>
+<body style="padding-bottom: 56px;">
 
+  <!-- MAIN NAV -->
   <header class="nav" id="nav">
     <div class="container nav__inner">
       <a href="/" class="nav__logo"><span>V</span>digital.</a>
@@ -52,172 +559,374 @@
     <a href="/#contact" class="btn btn--primary">Sākt projektu</a>
   </div>
 
-  <!-- HERO -->
-  <section class="preview-hero">
-    <div class="preview-hero__glow"></div>
-    <div class="container">
-      <div class="preview-hero__inner">
-        <div class="section-badge">Dzīvs priekšskatījums</div>
-        <h1>Kā izskatīsies <span>jūsu lapa</span>?</h1>
-        <p>Izvēlieties sava uzņēmuma veidu un apskatiet pilnu priekšskatījumu — gan datora, gan mobilā skatā. Katrs elements tiktu pielāgots jūsu zīmolam.</p>
+  <!-- STICKY CATEGORY PILLS -->
+  <nav class="pv-nav" aria-label="Kategorijas">
+    <button class="pv-nav__pill" data-target="restoran">🍽️ Restorāns</button>
+    <button class="pv-nav__pill" data-target="salons">💇 Skaistumkopšana</button>
+    <button class="pv-nav__pill" data-target="fitness">💪 Fitnesa klubs</button>
+  </nav>
+
+  <!-- ═══════════════════════════════════════
+       INTRO
+  ════════════════════════════════════════ -->
+  <section class="pv-intro" id="intro">
+    <div class="pv-intro__grid"></div>
+    <div class="pv-intro__glow"></div>
+    <div class="pv-intro__content">
+      <div class="pv-intro__eyebrow">
+        <span></span>
+        Dzīvs priekšskatījums
+      </div>
+      <h1 class="reveal">Katrs bizness ir<br/><em>atšķirīgs</em></h1>
+      <p class="pv-intro__sub reveal reveal-delay-1">Tāpēc katrai mājas lapai ir cita pieeja. Ritiniet zemāk un uzziniet, ko tieši jūsu nozare prasa — un ko mēs jums izveidosim.</p>
+      <div class="pv-intro__scroll reveal reveal-delay-2">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+        Ritināt zemāk
       </div>
     </div>
   </section>
 
-  <!-- CATEGORY GRID -->
-  <section class="cat-section">
-    <div class="container">
-      <div class="cat-grid">
+  <div class="pv-divider"></div>
 
-        <!-- Restaurant -->
-        <a href="/preview-restoran" class="cat-card" style="--cat-accent:#f59e0b; --cat-glow:rgba(245,158,11,0.2);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">🍽️</div>
-          <div class="cat-card__body">
-            <h3>Restorāns / Kafejnīca</h3>
-            <p>Izvēlne, rezervācija, galerija, atsauksmes</p>
-          </div>
-          <div class="cat-card__arrow">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-          </div>
-          <div class="cat-card__tag">Skatīt piemēru</div>
-        </a>
+  <!-- ═══════════════════════════════════════
+       1. RESTORĀNS
+  ════════════════════════════════════════ -->
+  <section class="pv-cat pv-cat--restoran" id="restoran">
+    <div class="pv-cat__bg">
+      <img
+        src="https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=1400"
+        alt="Restorāna interjers"
+        loading="lazy"
+      />
+    </div>
+    <div class="pv-cat__overlay"></div>
+    <div class="pv-cat__inner">
 
-        <!-- Salon -->
-        <a href="/preview-salons" class="cat-card" style="--cat-accent:#ec4899; --cat-glow:rgba(236,72,153,0.2);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">💇</div>
-          <div class="cat-card__body">
-            <h3>Skaistumkopšana / Barbershop</h3>
-            <p>Pakalpojumi, cenas, rezervācija, komanda</p>
+      <!-- Left: story -->
+      <div class="pv-cat__story">
+        <div class="pv-cat__number">01</div>
+        <div class="pv-cat__label">🍽️ Restorāns / Kafejnīca</div>
+        <h2 class="pv-cat__title reveal">Klients izvēlas<br/><span>ar acīm</span></h2>
+        <p class="pv-cat__quote reveal reveal-delay-1">"Pirms ienākt restorānā, cilvēks skatās uz foto. Ja lapā nav attēlu — restorāna viņam nav."
+        </p>
+        <div class="pv-cat__elements">
+          <div class="pv-cat__el reveal reveal-delay-1">
+            <div class="pv-cat__el-icon">🎬</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Video vai foto hero</div>
+              <div class="pv-cat__el-desc">Pirmais iespaids — atmosfēra, kas pārdod vēl pirms lasīšanas</div>
+            </div>
           </div>
-          <div class="cat-card__arrow">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          <div class="pv-cat__el reveal reveal-delay-2">
+            <div class="pv-cat__el-icon">📋</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Digitālā ēdienkarte</div>
+              <div class="pv-cat__el-desc">Kategorijas, cenas, foto — vienmēr aktuāla, bez drukāšanas</div>
+            </div>
           </div>
-          <div class="cat-card__tag">Skatīt piemēru</div>
-        </a>
-
-        <!-- Fitness -->
-        <a href="/preview-fitness" class="cat-card" style="--cat-accent:#f97316; --cat-glow:rgba(249,115,22,0.2);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">💪</div>
-          <div class="cat-card__body">
-            <h3>Fitnesa / Sporta klubs</h3>
-            <p>Nodarbības, grafiks, abonements, atsauksmes</p>
+          <div class="pv-cat__el reveal reveal-delay-3">
+            <div class="pv-cat__el-icon">📅</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Tiešsaistes rezervācija</div>
+              <div class="pv-cat__el-desc">Klients rezervē galdiņu pats — jūs saņemat paziņojumu</div>
+            </div>
           </div>
-          <div class="cat-card__arrow">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          <div class="pv-cat__el reveal reveal-delay-4">
+            <div class="pv-cat__el-icon">⭐</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Google atsauksmes</div>
+              <div class="pv-cat__el-desc">Reālas atsauksmes automātiski parādās lapā — veido uzticību</div>
+            </div>
           </div>
-          <div class="cat-card__tag">Skatīt piemēru</div>
-        </a>
-
-        <!-- Construction (coming soon) -->
-        <div class="cat-card cat-card--soon" style="--cat-accent:#6366f1; --cat-glow:rgba(99,102,241,0.15);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">🔨</div>
-          <div class="cat-card__body">
-            <h3>Būvniecība / Renovācija</h3>
-            <p>Portfolio, pirms/pēc, atsauksmes, kontakts</p>
-          </div>
-          <div class="cat-card__soon-badge">Drīz</div>
         </div>
-
-        <!-- Retail (coming soon) -->
-        <div class="cat-card cat-card--soon" style="--cat-accent:#10b981; --cat-glow:rgba(16,185,129,0.15);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">🛍️</div>
-          <div class="cat-card__body">
-            <h3>Mazumtirdzniecība / Veikals</h3>
-            <p>Produkti, akcijas, darba laiks, karte</p>
-          </div>
-          <div class="cat-card__soon-badge">Drīz</div>
-        </div>
-
-        <!-- Clinic (coming soon) -->
-        <div class="cat-card cat-card--soon" style="--cat-accent:#14b8a6; --cat-glow:rgba(20,184,166,0.15);">
-          <div class="cat-card__glow"></div>
-          <div class="cat-card__icon">🏥</div>
-          <div class="cat-card__body">
-            <h3>Klīnika / Zobārstniecība</h3>
-            <p>Ārsti, pakalpojumi, rezervācija, sertifikāti</p>
-          </div>
-          <div class="cat-card__soon-badge">Drīz</div>
-        </div>
-
       </div>
 
-      <p class="cat-note">Nesarodat savā sarakstā? <a href="/#contact">Saziniet ies</a> — veidojam lapas jebkura veida uzņēmumiem.</p>
+      <!-- Right: live preview -->
+      <div class="pv-cat__preview reveal reveal-delay-1">
+        <div class="pv-preview-hero">
+          <div class="pv-preview-hero__bg" style="background-image:url('https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=800');"></div>
+          <div class="pv-preview-hero__content">
+            <div class="pv-preview-hero__name">Restorāns La Cena</div>
+            <div class="pv-preview-hero__sub">Itāļu virtuve · Rīgā kopš 2018</div>
+            <div class="pv-preview-cta">📅 Rezervēt galdiņu</div>
+          </div>
+        </div>
+        <div class="pv-preview-cards">
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🍝</div>
+            <div class="pv-preview-card__title">Pasta Carbonara</div>
+            <div class="pv-preview-card__val">€12.90</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🍕</div>
+            <div class="pv-preview-card__title">Margherita DOP</div>
+            <div class="pv-preview-card__val">€11.50</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🥩</div>
+            <div class="pv-preview-card__title">Ribeye steiks</div>
+            <div class="pv-preview-card__val">€22.00</div>
+          </div>
+        </div>
+        <div class="pv-preview-review">
+          <div class="pv-preview-review__avatar">👤</div>
+          <div>
+            <div class="pv-preview-review__stars">★★★★★</div>
+            <p>"Labākā pasta, ko esmu ēdis Rīgā. Atmosfēra romantiška, apkalpošana ātra."</p>
+            <div class="pv-preview-review__author">— Mārtiņš L., Rīga · Google</div>
+          </div>
+        </div>
+      </div>
+
     </div>
   </section>
 
-  <!-- HOW IT WORKS -->
-  <section class="how-section">
-    <div class="container">
-      <div class="section-header">
-        <div class="section-badge">Process</div>
-        <h2 class="section-title">No priekšskatījuma<br/>līdz <span style="color:var(--accent-2)">dzīvai lapai</span></h2>
+  <div class="pv-divider"></div>
+
+  <!-- ═══════════════════════════════════════
+       2. SKAISTUMKOPŠANA
+  ════════════════════════════════════════ -->
+  <section class="pv-cat pv-cat--salons" id="salons">
+    <div class="pv-cat__bg">
+      <img
+        src="https://images.pexels.com/photos/3993449/pexels-photo-3993449.jpeg?auto=compress&cs=tinysrgb&w=1400"
+        alt="Skaistumkopšanas salons"
+        loading="lazy"
+      />
+    </div>
+    <div class="pv-cat__overlay"></div>
+    <div class="pv-cat__inner">
+
+      <!-- Left -->
+      <div class="pv-cat__story">
+        <div class="pv-cat__number">02</div>
+        <div class="pv-cat__label">💇 Skaistumkopšana / Barbershop</div>
+        <h2 class="pv-cat__title reveal">Uzticība veidojas<br/><span>pirms apmeklējuma</span></h2>
+        <p class="pv-cat__quote reveal reveal-delay-1">"Klients izvēlas meistaru pēc darbu galerijas un atsauksmēm — ne pēc izkārtnes uz ielas."
+        </p>
+        <div class="pv-cat__elements">
+          <div class="pv-cat__el reveal reveal-delay-1">
+            <div class="pv-cat__el-icon">👥</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Meistaru profili</div>
+              <div class="pv-cat__el-desc">Foto, specialitāte, pieredze — klients izvēlas, pie kā iet</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-2">
+            <div class="pv-cat__el-icon">💰</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Cenu saraksts</div>
+              <div class="pv-cat__el-desc">Caurskatāmas cenas — nav jāzvana, lai uzzinātu</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-3">
+            <div class="pv-cat__el-icon">🖼️</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Darbu galerija</div>
+              <div class="pv-cat__el-desc">Pirms/pēc foto un stilu piemēri pārdod labāk nekā vārdi</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-4">
+            <div class="pv-cat__el-icon">📲</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Tiešsaistes pieraksts</div>
+              <div class="pv-cat__el-desc">Klienti pierakstās 24/7 — arī tad, kad salons ir slēgts</div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="how-steps">
-        <div class="how-step">
-          <div class="how-step__num">01</div>
-          <h3>Izvēlaties stilu</h3>
-          <p>Apskatiet piemērus augstāk un saprotiet, kāds dizains jūsu biznesam der vislabāk.</p>
+
+      <!-- Right -->
+      <div class="pv-cat__preview reveal reveal-delay-1">
+        <div class="pv-preview-hero">
+          <div class="pv-preview-hero__bg" style="background-image:url('https://images.pexels.com/photos/3065209/pexels-photo-3065209.jpeg?auto=compress&cs=tinysrgb&w=800');"></div>
+          <div class="pv-preview-hero__content">
+            <div class="pv-preview-hero__name">Glamour Zone</div>
+            <div class="pv-preview-hero__sub">Skaistumkopšana · Rīgā</div>
+            <div class="pv-preview-cta">📅 Pierakstīties</div>
+          </div>
         </div>
-        <div class="how-step__line"></div>
-        <div class="how-step">
-          <div class="how-step__num">02</div>
-          <h3>Sazināties ar mums</h3>
-          <p>Bezàmaksas konsultācija — pastāstiet par savu uzņēmumu, mēs apstiprinām termiņus.</p>
+        <div class="pv-preview-cards">
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">✂️</div>
+            <div class="pv-preview-card__title">Matu griezums</div>
+            <div class="pv-preview-card__val">no €18</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🌈</div>
+            <div class="pv-preview-card__title">Balayage</div>
+            <div class="pv-preview-card__val">no €85</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">💅</div>
+            <div class="pv-preview-card__title">Manikjurs</div>
+            <div class="pv-preview-card__val">no €15</div>
+          </div>
         </div>
-        <div class="how-step__line"></div>
-        <div class="how-step">
-          <div class="how-step__num">03</div>
-          <h3>Lapa ir gatava</h3>
-          <p>7–14 dienu laikā jūsu lapa ir dzīva, Google indeksēta un gatava uztvērt klientus.</p>
+        <div class="pv-preview-review">
+          <div class="pv-preview-review__avatar">👤</div>
+          <div>
+            <div class="pv-preview-review__stars">★★★★★</div>
+            <p>"Laura ir burve! Balayage izdevās perfekti — precizitāte augstākā līmenī."</p>
+            <div class="pv-preview-review__author">— Sanita R., Rīga · Google</div>
+          </div>
         </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="pv-divider"></div>
+
+  <!-- ═══════════════════════════════════════
+       3. FITNESS
+  ════════════════════════════════════════ -->
+  <section class="pv-cat pv-cat--fitness" id="fitness">
+    <div class="pv-cat__bg">
+      <img
+        src="https://images.pexels.com/photos/1552242/pexels-photo-1552242.jpeg?auto=compress&cs=tinysrgb&w=1400"
+        alt="Fitnesa klubs"
+        loading="lazy"
+      />
+    </div>
+    <div class="pv-cat__overlay"></div>
+    <div class="pv-cat__inner">
+
+      <!-- Left -->
+      <div class="pv-cat__story">
+        <div class="pv-cat__number">03</div>
+        <div class="pv-cat__label">💪 Fitnesa / Sporta klubs</div>
+        <h2 class="pv-cat__title reveal">Motivācija sākas<br/><span>ar pirmo skatienu</span></h2>
+        <p class="pv-cat__quote reveal reveal-delay-1">"Potenciālais klients lēmumu pieņem 8 sekundēs. Lapai jāenerģizē — uzreiz."
+        </p>
+        <div class="pv-cat__elements">
+          <div class="pv-cat__el reveal reveal-delay-1">
+            <div class="pv-cat__el-icon">🎬</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Energētisks hero</div>
+              <div class="pv-cat__el-desc">Video vai foto, kas uzreiz rada sajūtu — "es gribu šeit trenēties"</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-2">
+            <div class="pv-cat__el-icon">📆</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Nodarbību grafiks</div>
+              <div class="pv-cat__el-desc">Interaktīvs nedēļas grafiks — klients redz, kad var nākt</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-3">
+            <div class="pv-cat__el-icon">💳</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">Abonementu cenas</div>
+              <div class="pv-cat__el-desc">3 līmeņu cenu tabula — vienkārša izvēle bez pārdomāšanas</div>
+            </div>
+          </div>
+          <div class="pv-cat__el reveal reveal-delay-4">
+            <div class="pv-cat__el-icon">🎯</div>
+            <div class="pv-cat__el-body">
+              <div class="pv-cat__el-title">"Pirmais bezmaksā" CTA</div>
+              <div class="pv-cat__el-desc">Vieglākais veids, kā pārvērst apmeklētāju par klientu</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right -->
+      <div class="pv-cat__preview reveal reveal-delay-1">
+        <div class="pv-preview-hero">
+          <div class="pv-preview-hero__bg" style="background-image:url('https://images.pexels.com/photos/841130/pexels-photo-841130.jpeg?auto=compress&cs=tinysrgb&w=800');"></div>
+          <div class="pv-preview-hero__content">
+            <div class="pv-preview-hero__name">PowerFit Rīga</div>
+            <div class="pv-preview-hero__sub">Atvērts 06:00–22:00 · 7 dienas</div>
+            <div class="pv-preview-cta">🏋️ Pirmais bezmaksā</div>
+          </div>
+        </div>
+        <div class="pv-preview-cards">
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🧘</div>
+            <div class="pv-preview-card__title">Yoga & Stretch</div>
+            <div class="pv-preview-card__val">P/T/P · 07:00</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🔥</div>
+            <div class="pv-preview-card__title">HIIT Cardio</div>
+            <div class="pv-preview-card__val">O/C/S · 18:30</div>
+          </div>
+          <div class="pv-preview-card">
+            <div class="pv-preview-card__top">🥊</div>
+            <div class="pv-preview-card__title">Bokss</div>
+            <div class="pv-preview-card__val">P/C · 20:00</div>
+          </div>
+        </div>
+        <div class="pv-preview-review">
+          <div class="pv-preview-review__avatar">👤</div>
+          <div>
+            <div class="pv-preview-review__stars">★★★★★</div>
+            <p>"3 mēnešos zaudēju 8 kg. Andris ir fantastisks treneris — motivē un prot skaidrot."</p>
+            <div class="pv-preview-review__author">— Jānis O., Rīga · Google</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="pv-divider"></div>
+
+  <!-- ═══════════════════════════════════════
+       CLOSING CTA
+  ════════════════════════════════════════ -->
+  <section class="pv-cta">
+    <div class="pv-cta__glow"></div>
+    <div class="pv-cta__inner">
+      <div class="pv-cta__kicker">Gatavs sākt?</div>
+      <h2 class="reveal">Jūsu uzņēmums varētu<br/>izskatīties <span>tieši tā</span></h2>
+      <p class="reveal reveal-delay-1">Pirmā konsultācija bez maksas. Pastāstiet par savu biznesu — mēs izveidosim lapu, kas pārdod.</p>
+      <div class="pv-cta__btns reveal reveal-delay-2">
+        <a href="/#contact" class="btn btn--primary btn--lg">Sākt projektu →</a>
+        <a href="/#packages" class="btn btn--outline btn--lg">Skatīt cenas</a>
       </div>
     </div>
   </section>
 
-  <!-- CTA -->
-  <section class="preview-cta">
-    <div class="container">
-      <div class="preview-cta__inner">
-        <div class="preview-cta__glow"></div>
-        <h2>Gatavs sākt?</h2>
-        <p>Pirmā konsultācija bez maksas. Pastāstiet par savu uzņēmumu — mēs parādīsim, kā varētu izskatīties tieši jūsu lapa.</p>
-        <div class="btn-group">
-          <a href="/#contact" class="btn btn--primary btn--lg">Sazināties →</a>
-          <a href="/#packages" class="btn btn--outline btn--lg">Skatīt cenas</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <footer class="footer">
-    <div class="container footer__inner">
-      <div class="footer__left">
-        <a href="/" class="nav__logo"><span>V</span>digital.</a>
-        <p>Jūsu biznesa digitālā identitāte sākas šeit.</p>
-      </div>
-      <div class="footer__links">
-        <a href="/#services">Pakalpojumi</a>
-        <a href="/#packages">Cenas</a>
-        <a href="/#work">Darbi</a>
-        <a href="/#contact">Kontakts</a>
-      </div>
-    </div>
-    <div class="container footer__bottom">
-      <span>© 2026 Vdigital. Visas tiesības aizsargātas.</span>
-    </div>
-  </footer>
-
-  <a href="https://wa.me/37125953807" class="whatsapp-float" target="_blank" rel="noopener" aria-label="Sazināties WhatsApp">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>
-    <span class="whatsapp-float__tooltip">Rakstīt WhatsApp</span>
-  </a>
+  <!-- VDIGITAL STICKY BAR -->
+  <div class="vd-bar">
+    <span class="vd-bar__text">⚡ <strong>Vdigital</strong> izveido šāda līmeņa mājas lapas Latvijas uzņēmumiem</span>
+    <a href="/#contact" class="vd-bar__cta">Gribu tādu pašu →</a>
+  </div>
 
   <script src="js/theme.js"></script>
   <script src="js/nav.js"></script>
+  <script>
+    // Scroll reveal
+    const revealEls = document.querySelectorAll('.reveal');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); observer.unobserve(e.target); } });
+    }, { threshold: 0.12 });
+    revealEls.forEach(el => observer.observe(el));
+
+    // Active pill on scroll
+    const sections = ['restoran','salons','fitness'];
+    const pills = document.querySelectorAll('.pv-nav__pill');
+    const scrollSpy = new IntersectionObserver((entries) => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          pills.forEach(p => p.classList.remove('active'));
+          const pill = document.querySelector(`.pv-nav__pill[data-target="${e.target.id}"]`);
+          if (pill) pill.classList.add('active');
+        }
+      });
+    }, { threshold: 0.4 });
+    sections.forEach(id => { const el = document.getElementById(id); if(el) scrollSpy.observe(el); });
+
+    // Pill click scroll
+    pills.forEach(pill => {
+      pill.addEventListener('click', () => {
+        const target = document.getElementById(pill.dataset.target);
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Preview v2 — one page, one story

Complete rebuild of `/preview`. Replaces the old multi-page mockup system with a single scroll-driven storytelling page.

### What's in it
- **Intro hero** — big headline, animated scroll prompt, grid background
- **3 full-viewport category sections** — Restaurant, Salon, Fitness — each with:
  - Real Pexels photo background (dark overlay, mood-matched)
  - Left: story, quote, 4 key elements explained
  - Right: live-feeling preview card (hero photo, 3 feature cards, review)
  - Unique accent colour per category (`#f59e0b` / `#ec4899` / `#f97316`)
- **Sticky pill nav** — highlights active section on scroll, click to jump
- **Closing CTA** — *"Jūsu uzņēmums varētu izskatīties tieši tā"*
- **Vdigital sticky bottom bar** — subtle attribution + *"Gribu tādu pašu →"*
- **Scroll reveal** — elements animate in as user scrolls
- Zero emoji placeholders — real photos throughout